### PR TITLE
Add kt_jvm_grpc_library Bazel rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,1 @@
+# Deliberately empty

--- a/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 licenses(["notice"])
 
 package(
-    default_visibility = ["//:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 kt_jvm_library(

--- a/examples/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
+++ b/examples/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "hello_world",
+    srcs = ["HelloWorldServer.kt"],
+    deps = ["//examples/src/main/proto:foo"],
+)

--- a/examples/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
+++ b/examples/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
@@ -3,5 +3,5 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 kt_jvm_library(
     name = "hello_world",
     srcs = ["HelloWorldServer.kt"],
-    deps = ["//examples/src/main/proto:foo"],
+    deps = ["//examples/src/main/proto:hello_world_kt_grpc"],
 )

--- a/examples/src/main/proto/BUILD.bazel
+++ b/examples/src/main/proto/BUILD.bazel
@@ -20,3 +20,11 @@ java_grpc_library(
     srcs = [":hello_world_proto"],
     deps = [":hello_world_java_proto"],
 )
+
+load("//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library")
+
+kt_jvm_grpc_library(
+    name = "foo",
+    srcs = [":hello_world_proto"],
+    deps = [":hello_world_java_proto"],
+)

--- a/examples/src/main/proto/BUILD.bazel
+++ b/examples/src/main/proto/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library")
 
 licenses(["notice"])
 
@@ -21,10 +22,8 @@ java_grpc_library(
     deps = [":hello_world_java_proto"],
 )
 
-load("//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library")
-
 kt_jvm_grpc_library(
-    name = "foo",
+    name = "hello_world_kt_grpc",
     srcs = [":hello_world_proto"],
     deps = [":hello_world_java_proto"],
 )

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -123,10 +123,9 @@ def kt_jvm_grpc_library(
         kt_grpc_deps = [
             "@io_grpc_grpc_java//stub",
             "@io_grpc_grpc_java//context",
-            "//stub/src/main/java/io/grpc/kotlin:stub",
-            "//stub/src/main/java/io/grpc/kotlin:context",
+            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
+            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:context",
         ]
-
     elif flavor == "lite":
         fail("Android support is unimplemented")
     else:

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -1,0 +1,189 @@
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin/internal/jvm:impl.bzl", "kt_jvm_library_impl")
+
+def _java_grpc_name(name):
+    return ":%s_DO_NOT_DEPEND_java_grpc" % name
+
+def _kt_grpc_name(name):
+    return ":%s_DO_NOT_DEPEND_kt_grpc" % name
+
+def _collect_providers(provider, deps):
+    """Collects the requested provider from the given list of deps."""
+    return [dep[provider] for dep in deps if provider in dep]
+
+def _kt_grpc_extensions_impl(ctx):
+    direct_descriptor_set = depset([dep[ProtoInfo].direct_descriptor_set for dep in ctx.attr.proto_deps])
+    transitive_descriptor_set = depset(
+        transitive = [dep[ProtoInfo].transitive_descriptor_sets for dep in ctx.attr.proto_deps],
+    )
+
+    gen_src_dir = ctx.actions.declare_directory(ctx.label.name + "/ktgrpc")
+
+    gensrc_args = ctx.actions.args()
+    gensrc_args.add(gen_src_dir.path)  # have to explicitly write .path for a directory
+    gensrc_args.add_all(direct_descriptor_set)
+    gensrc_args.add("--")
+    gensrc_args.add_all(transitive_descriptor_set)
+
+    ctx.actions.run(
+        outputs = [gen_src_dir],
+        inputs = depset(transitive = [direct_descriptor_set, transitive_descriptor_set]),
+        arguments = [gensrc_args],
+        progress_message = "Generating Kotlin gRPC extensions for " +
+                           ", ".join([str(dep.label) for dep in ctx.attr.proto_deps]),
+        executable = ctx.executable._generator,
+        mnemonic = "KtGrpcExtensions",
+    )
+
+    output_jar = ctx.actions.declare_file("some_jar.jar")
+    source_jar = ctx.actions.declare_file("some_jar.srcjar")
+
+    java_info = java_common.compile(
+        ctx,
+        source_files = [gen_src_dir],
+        output = output_jar,
+        java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
+        host_javabase = ctx.attr._host_javabase[java_common.JavaRuntimeInfo],
+    )
+
+    zipper_args = ctx.actions.args()
+    zipper_args.add_all(depset([gen_src_dir]))
+    ctx.actions.run_shell(
+        outputs = [source_jar],
+        inputs = [gen_src_dir],
+        tools = [ctx.executable._zipper],
+        arguments = [zipper_args],
+        command = "{zipper} c {output_jar} $1".format(
+            output_jar = source_jar.path,
+            zipper = ctx.executable._zipper.path,
+        ),
+    )
+
+    return [java_info, DefaultInfo(files = depset([source_jar, gen_src_dir]))]
+
+_kt_grpc_library_helper = rule(
+    attrs = dict(
+        proto_deps = attr.label_list(
+            providers = [ProtoInfo],
+        ),
+        deps = attr.label_list(
+            providers = [JavaInfo],
+        ),
+        exports = attr.label_list(
+            allow_rules = ["_java_grpc_library", "_java_lite_grpc_library"],
+        ),
+        _zipper = attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/zip:zipper"),
+            allow_files = True,
+        ),
+        _java_toolchain = attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        ),
+        _host_javabase = attr.label(
+            cfg = "host",
+            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+        ),
+        _generator = attr.label(
+            default = Label("//compiler/src/main/java/io/grpc/kotlin/generator:GeneratorRunner"),
+            cfg = "host",
+            executable = True,
+        ),
+    ),
+    fragments = ["java"],
+    provides = [JavaInfo],
+    implementation = _kt_grpc_extensions_impl,
+)
+
+def kt_jvm_grpc_library(
+        name,
+        srcs = None,
+        deps = None,
+        tags = None,
+        testonly = None,  # None to not override Blaze's default for //javatests, b/112708042
+        compatible_with = None,
+        restricted_to = None,
+        visibility = None,
+        flavor = None,
+        deprecation = None,
+        features = []):
+    """This rule compiles Kotlin APIs for gRPC services from the proto_library targets in deps.
+
+    In particular, it builds the java_grpc_library for the target and then Kotlin extensions
+    atop that.  This rule can be depended on from Java and Kotlin targets, without conflicting with
+    a java_grpc_library for the same target.
+
+    Args:
+      name: a name for the target
+      srcs: exactly one proto_library targets, to generate Kotlin APIs for
+      deps: exactly one JVM proto_library target for srcs: should be either java_proto_library,
+            java_lite_proto_library, kt_jvm_proto_library, or kt_jvm_lite_proto_library
+            targets
+      tags: A list of string tags passed to generated targets.
+      testonly: Whether this target is intended only for tests.
+      compatible_with: Standard attribute, see http://go/be-common#common.compatible_with
+      restricted_to: Standard attribute, see http://go/be-common#common.restricted_to
+      visibility: A list of targets allowed to depend on this rule.
+      flavor: "normal" (default) for normal proto runtime, or "lite" for the lite runtime
+        (for Android usage)
+      deprecation: Standard attribute, see http://go/be-common#common.deprecation
+      features: Features enabled.
+    """
+
+    srcs = srcs or []
+    deps = deps or []
+
+    if len(srcs) != 1:
+        fail("Expected exactly one src", "srcs")
+    if len(deps) != 1:
+        fail("Expected exactly one dep", "deps")
+
+    if flavor == None or flavor == "normal":
+        kt_grpc_deps = [
+            "@io_grpc_grpc_java//stub",
+            "@io_grpc_grpc_java//context",
+            "//stub/src/main/java/io/grpc/kotlin:stub",
+        ]
+
+    elif flavor == "lite":
+        fail("Android support is unimplemented")
+    else:
+        fail("Flavor must be normal or lite")
+
+    java_grpc_library(
+        name = _java_grpc_name(name)[1:],
+        srcs = srcs,
+        deps = deps,
+        compatible_with = compatible_with,
+        visibility = ["//visibility:private"],
+        flavor = flavor,
+        restricted_to = restricted_to,
+        testonly = testonly,
+        deprecation = deprecation,
+        features = features,
+    )
+
+    gen_rule_label = _kt_grpc_name(name)
+    gen_rule_name = gen_rule_label[1:]
+    grpc_deps = [_java_grpc_name(name)] + kt_grpc_deps
+
+    _kt_grpc_library_helper(
+        name = gen_rule_name,
+        proto_deps = srcs,
+        deps = grpc_deps,
+        exports = [_java_grpc_name(name)],
+        compatible_with = compatible_with,
+        restricted_to = restricted_to,
+        testonly = testonly,
+        visibility = visibility,
+        deprecation = deprecation,
+        features = features,
+    )
+
+    kt_jvm_library(
+        name = name,
+        srcs = [gen_rule_label],
+        deps = grpc_deps,
+    )

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -1,66 +1,55 @@
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
-load("@io_bazel_rules_kotlin//kotlin/internal/jvm:impl.bzl", "kt_jvm_library_impl")
 
-def _java_grpc_name(name):
-    return ":%s_DO_NOT_DEPEND_java_grpc" % name
+def _invoke_generator(ctx, proto_dep, output_dir):
+    direct_descriptor_set = depset([proto_dep[ProtoInfo].direct_descriptor_set])
+    transitive_descriptor_set = depset(transitive = [proto_dep[ProtoInfo].transitive_descriptor_sets])
 
-def _kt_grpc_name(name):
-    return ":%s_DO_NOT_DEPEND_kt_grpc" % name
-
-def _collect_providers(provider, deps):
-    """Collects the requested provider from the given list of deps."""
-    return [dep[provider] for dep in deps if provider in dep]
-
-def _kt_grpc_extensions_impl(ctx):
-    direct_descriptor_set = depset([dep[ProtoInfo].direct_descriptor_set for dep in ctx.attr.proto_deps])
-    transitive_descriptor_set = depset(
-        transitive = [dep[ProtoInfo].transitive_descriptor_sets for dep in ctx.attr.proto_deps],
-    )
-
-    gen_src_dir = ctx.actions.declare_directory(ctx.label.name + "/ktgrpc")
-
-    gensrc_args = ctx.actions.args()
-    gensrc_args.add(gen_src_dir.path)  # have to explicitly write .path for a directory
-    gensrc_args.add_all(direct_descriptor_set)
-    gensrc_args.add("--")
-    gensrc_args.add_all(transitive_descriptor_set)
+    args = ctx.actions.args()
+    args.add(output_dir.path)  # have to explicitly write .path for a directory
+    args.add_all(direct_descriptor_set)
+    args.add("--")
+    args.add_all(transitive_descriptor_set)
 
     ctx.actions.run(
-        outputs = [gen_src_dir],
+        outputs = [output_dir],
         inputs = depset(transitive = [direct_descriptor_set, transitive_descriptor_set]),
-        arguments = [gensrc_args],
-        progress_message = "Generating Kotlin gRPC extensions for " +
-                           ", ".join([str(dep.label) for dep in ctx.attr.proto_deps]),
+        arguments = [args],
         executable = ctx.executable._generator,
-        mnemonic = "KtGrpcExtensions",
+        mnemonic = "KtGrpcGenerator",
+        progress_message = "Generating Kotlin gRPC extensions for %s" % proto_dep.label,
     )
 
-    output_jar = ctx.actions.declare_file("some_jar.jar")
-    source_jar = ctx.actions.declare_file("some_jar.srcjar")
-
-    java_info = java_common.compile(
-        ctx,
-        source_files = [gen_src_dir],
-        output = output_jar,
-        java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
-        host_javabase = ctx.attr._host_javabase[java_common.JavaRuntimeInfo],
-    )
-
-    zipper_args = ctx.actions.args()
-    zipper_args.add_all(depset([gen_src_dir]))
+def _build_srcjar(ctx, proto_dep, input_dir, source_jar):
+    args = ctx.actions.args()
+    args.add("c")
+    args.add(source_jar.path)
+    args.add_all(depset([input_dir]))
     ctx.actions.run_shell(
         outputs = [source_jar],
-        inputs = [gen_src_dir],
+        inputs = [input_dir],
         tools = [ctx.executable._zipper],
-        arguments = [zipper_args],
-        command = "{zipper} c {output_jar} $1".format(
-            output_jar = source_jar.path,
-            zipper = ctx.executable._zipper.path,
-        ),
+        arguments = [args],
+        command = "{zipper} $1 $2 $3".format(zipper = ctx.executable._zipper.path),
+        mnemonic = "KtGrpcSrcJar",
+        progress_message = "Generating Kotlin gRPC srcjar for %s" % proto_dep.label,
     )
 
-    return [java_info, DefaultInfo(files = depset([source_jar, gen_src_dir]))]
+def _kt_grpc_extensions_impl(ctx):
+    proto_dep = ctx.attr.proto_deps[0]
+    name = ctx.label.name
+
+    gen_src_dir_name = "%s/ktgrpc" % name
+    gen_src_dir = ctx.actions.declare_directory(gen_src_dir_name)
+    source_jar = ctx.actions.declare_file("some_jar.srcjar")
+
+    _invoke_generator(ctx, proto_dep, gen_src_dir)
+    _build_srcjar(ctx, proto_dep, gen_src_dir, source_jar)
+
+    java_info = ctx.attr.deps[0][JavaInfo]
+    default_info = DefaultInfo(files = depset([source_jar, gen_src_dir]))
+
+    return [java_info, default_info]
 
 _kt_grpc_library_helper = rule(
     attrs = dict(
@@ -70,21 +59,11 @@ _kt_grpc_library_helper = rule(
         deps = attr.label_list(
             providers = [JavaInfo],
         ),
-        exports = attr.label_list(
-            allow_rules = ["_java_grpc_library", "_java_lite_grpc_library"],
-        ),
         _zipper = attr.label(
             executable = True,
             cfg = "host",
             default = Label("@bazel_tools//tools/zip:zipper"),
             allow_files = True,
-        ),
-        _java_toolchain = attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
-        ),
-        _host_javabase = attr.label(
-            cfg = "host",
-            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
         ),
         _generator = attr.label(
             default = Label("//compiler/src/main/java/io/grpc/kotlin/generator:GeneratorRunner"),
@@ -145,6 +124,7 @@ def kt_jvm_grpc_library(
             "@io_grpc_grpc_java//stub",
             "@io_grpc_grpc_java//context",
             "//stub/src/main/java/io/grpc/kotlin:stub",
+            "//stub/src/main/java/io/grpc/kotlin:context",
         ]
 
     elif flavor == "lite":
@@ -152,8 +132,16 @@ def kt_jvm_grpc_library(
     else:
         fail("Flavor must be normal or lite")
 
+    kt_grpc_label = ":%s_DO_NOT_DEPEND_kt_grpc" % name
+    java_grpc_label = ":%s_DO_NOT_DEPEND_java_grpc" % name
+
+    kt_grpc_name = kt_grpc_label[1:]
+    java_grpc_name = java_grpc_label[1:]
+
+    grpc_deps = [java_grpc_label] + kt_grpc_deps
+
     java_grpc_library(
-        name = _java_grpc_name(name)[1:],
+        name = java_grpc_name,
         srcs = srcs,
         deps = deps,
         compatible_with = compatible_with,
@@ -165,25 +153,21 @@ def kt_jvm_grpc_library(
         features = features,
     )
 
-    gen_rule_label = _kt_grpc_name(name)
-    gen_rule_name = gen_rule_label[1:]
-    grpc_deps = [_java_grpc_name(name)] + kt_grpc_deps
-
     _kt_grpc_library_helper(
-        name = gen_rule_name,
+        name = kt_grpc_name,
         proto_deps = srcs,
         deps = grpc_deps,
-        exports = [_java_grpc_name(name)],
+    )
+
+    kt_jvm_library(
+        name = name,
+        srcs = [kt_grpc_label],
+        deps = grpc_deps,
+        exports = [java_grpc_label],
         compatible_with = compatible_with,
         restricted_to = restricted_to,
         testonly = testonly,
         visibility = visibility,
         deprecation = deprecation,
         features = features,
-    )
-
-    kt_jvm_library(
-        name = name,
-        srcs = [gen_rule_label],
-        deps = grpc_deps,
     )

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -41,7 +41,7 @@ def _kt_grpc_extensions_impl(ctx):
 
     gen_src_dir_name = "%s/ktgrpc" % name
     gen_src_dir = ctx.actions.declare_directory(gen_src_dir_name)
-    source_jar = ctx.actions.declare_file("some_jar.srcjar")
+    source_jar = ctx.actions.declare_file("%s.srcjar" % name)
 
     _invoke_generator(ctx, proto_dep, gen_src_dir)
     _build_srcjar(ctx, proto_dep, gen_src_dir, source_jar)

--- a/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 licenses(["notice"])
 
 package(
-    default_visibility = ["//:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 kt_jvm_library(


### PR DESCRIPTION
This adds a bazel library, `kt_jvm_grpc.bzl`, implementing `kt_jvm_grpc_library`.