### PR TITLE
Clean up kt_jvm_grpc.bzl and WORKSPACE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .idea
 local.properties
 *.iml
+/bazel-*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,34 +1,6 @@
 workspace(name = "com_github_grpc_grpc_kotlin")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "build_bazel_rules_android",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-)
-
-rules_kotlin_version = "b40d920c5a5e044c541513f0d5e9260d0a4579c0"
-http_archive(
-    name = "io_bazel_rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
-    sha256 = "3dadd0ad7272be6b1ed1274f62cadd4a1293c89990bcd7b4af32637a70ada63e",
-    type = "zip",
-    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version
-)
-
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-kotlin_repositories()
-kt_register_toolchains()
-
-http_archive(
-    name = "io_grpc_grpc_java",
-    sha256 = "e274597cc4de351b4f79e4c290de8175c51a403dc39f83f1dfc50a1d1c9e9a4f",
-    strip_prefix = "grpc-java-1.28.0",
-    url = "https://github.com/grpc/grpc-java/archive/v1.28.0.zip",
-)
-
-load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
 
 http_archive(
     name = "rules_jvm_external",
@@ -38,17 +10,34 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load(
+    "//:repositories.bzl",
+    "IO_GRPC_GRPC_KOTLIN_ARTIFACTS",
+    "IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS",
+    "grpc_kt_repositories",
+)
+
+http_archive(
+    name = "io_grpc_grpc_java",
+    sha256 = "e274597cc4de351b4f79e4c290de8175c51a403dc39f83f1dfc50a1d1c9e9a4f",
+    strip_prefix = "grpc-java-1.28.0",
+    url = "https://github.com/grpc/grpc-java/archive/v1.28.0.zip",
+)
+
+load(
+    "@io_grpc_grpc_java//:repositories.bzl",
+    "IO_GRPC_GRPC_JAVA_ARTIFACTS",
+    "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS",
+    "grpc_java_repositories",
+)
 
 maven_install(
-    artifacts = [
-        "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24",
-        "com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.24",
-        "com.google.guava:guava:29.0-jre",
-        "com.squareup:kotlinpoet:1.5.0",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",
-    ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    artifacts = IO_GRPC_GRPC_KOTLIN_ARTIFACTS + IO_GRPC_GRPC_JAVA_ARTIFACTS,
     generate_compat_repositories = True,
-    override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
+    override_targets = dict(
+        IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS.items() +
+        IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS.items(),
+    ),
     repositories = [
         "https://repo.maven.apache.org/maven2/",
     ],
@@ -58,9 +47,20 @@ load("@maven//:compat.bzl", "compat_repositories")
 
 compat_repositories()
 
-# Run grpc_java_repositories after compat_repositories to ensure the
-# maven_install-selected dependencies are used.
+grpc_kt_repositories()
+
 grpc_java_repositories()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
+
+load(
+    "@io_bazel_rules_kotlin//kotlin:kotlin.bzl",
+    "kotlin_repositories",
+    "kt_register_toolchains",
+)
+
+kotlin_repositories()
+
+kt_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,19 +10,17 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+# Repositories
 load(
     "//:repositories.bzl",
     "IO_GRPC_GRPC_KOTLIN_ARTIFACTS",
     "IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS",
     "grpc_kt_repositories",
+    "io_grpc_grpc_java",
 )
 
-http_archive(
-    name = "io_grpc_grpc_java",
-    sha256 = "e274597cc4de351b4f79e4c290de8175c51a403dc39f83f1dfc50a1d1c9e9a4f",
-    strip_prefix = "grpc-java-1.28.0",
-    url = "https://github.com/grpc/grpc-java/archive/v1.28.0.zip",
-)
+io_grpc_grpc_java()
 
 load(
     "@io_grpc_grpc_java//:repositories.bzl",
@@ -31,6 +29,7 @@ load(
     "grpc_java_repositories",
 )
 
+# Maven
 maven_install(
     artifacts = IO_GRPC_GRPC_KOTLIN_ARTIFACTS + IO_GRPC_GRPC_JAVA_ARTIFACTS,
     generate_compat_repositories = True,
@@ -47,14 +46,17 @@ load("@maven//:compat.bzl", "compat_repositories")
 
 compat_repositories()
 
+# gRPC
 grpc_kt_repositories()
 
 grpc_java_repositories()
 
+# Protocol Buffers
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+# Kotlin
 load(
     "@io_bazel_rules_kotlin//kotlin:kotlin.bzl",
     "kotlin_repositories",

--- a/examples/src/main/proto/BUILD.bazel
+++ b/examples/src/main/proto/BUILD.bazel
@@ -25,5 +25,5 @@ java_grpc_library(
 kt_jvm_grpc_library(
     name = "hello_world_kt_grpc",
     srcs = [":hello_world_proto"],
-    deps = [":hello_world_java_proto"],
+    deps = [":hello_world_java_grpc"],
 )

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -140,7 +140,7 @@ def kt_jvm_grpc_library(
         name = name,
         srcs = [kt_grpc_label],
         deps = deps,
-        exports = [deps[0]],
+        exports = deps,
         compatible_with = compatible_with,
         restricted_to = restricted_to,
         testonly = testonly,

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -1,4 +1,3 @@
-load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 
 def _invoke_generator(ctx, proto_dep, output_dir):
@@ -88,18 +87,15 @@ def kt_jvm_grpc_library(
         flavor = None,
         deprecation = None,
         features = []):
-    """This rule compiles Kotlin APIs for gRPC services from the proto_library targets in deps.
+    """This rule compiles Kotlin APIs for gRPC services from the proto_library in srcs.
 
-    In particular, it builds the java_grpc_library for the target and then Kotlin extensions
-    atop that.  This rule can be depended on from Java and Kotlin targets, without conflicting with
-    a java_grpc_library for the same target.
+    The Kotlin gRPC code generator requires a java_proto_library for the proto_library,
+    which should be passed in deps.
 
     Args:
       name: a name for the target
       srcs: exactly one proto_library targets, to generate Kotlin APIs for
-      deps: exactly one JVM proto_library target for srcs: should be either java_proto_library,
-            java_lite_proto_library, kt_jvm_proto_library, or kt_jvm_lite_proto_library
-            targets
+      deps: exactly one java_grpc_library target for srcs[0]
       tags: A list of string tags passed to generated targets.
       testonly: Whether this target is intended only for tests.
       compatible_with: Standard attribute, see http://go/be-common#common.compatible_with
@@ -120,49 +116,31 @@ def kt_jvm_grpc_library(
         fail("Expected exactly one dep", "deps")
 
     if flavor == None or flavor == "normal":
-        kt_grpc_deps = [
-            "@io_grpc_grpc_java//stub",
-            "@io_grpc_grpc_java//context",
-            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
-            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:context",
-        ]
+        pass
     elif flavor == "lite":
         fail("Android support is unimplemented")
     else:
         fail("Flavor must be normal or lite")
 
     kt_grpc_label = ":%s_DO_NOT_DEPEND_kt_grpc" % name
-    java_grpc_label = ":%s_DO_NOT_DEPEND_java_grpc" % name
-
     kt_grpc_name = kt_grpc_label[1:]
-    java_grpc_name = java_grpc_label[1:]
 
-    grpc_deps = [java_grpc_label] + kt_grpc_deps
-
-    java_grpc_library(
-        name = java_grpc_name,
-        srcs = srcs,
-        deps = deps,
-        compatible_with = compatible_with,
-        visibility = ["//visibility:private"],
-        flavor = flavor,
-        restricted_to = restricted_to,
-        testonly = testonly,
-        deprecation = deprecation,
-        features = features,
-    )
+    deps.extend([
+        "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
+        "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:context",
+    ])
 
     _kt_grpc_library_helper(
         name = kt_grpc_name,
         proto_deps = srcs,
-        deps = grpc_deps,
+        deps = deps,
     )
 
     kt_jvm_library(
         name = name,
         srcs = [kt_grpc_label],
-        deps = grpc_deps,
-        exports = [java_grpc_label],
+        deps = deps,
+        exports = [deps[0]],
         compatible_with = compatible_with,
         restricted_to = restricted_to,
         testonly = testonly,

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -116,7 +116,10 @@ def kt_jvm_grpc_library(
         fail("Expected exactly one dep", "deps")
 
     if flavor == None or flavor == "normal":
-        pass
+        deps.extend([
+            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
+            "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:context",
+        ])
     elif flavor == "lite":
         fail("Android support is unimplemented")
     else:
@@ -124,11 +127,6 @@ def kt_jvm_grpc_library(
 
     kt_grpc_label = ":%s_DO_NOT_DEPEND_kt_grpc" % name
     kt_grpc_name = kt_grpc_label[1:]
-
-    deps.extend([
-        "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:stub",
-        "@com_github_grpc_grpc_kotlin//stub/src/main/java/io/grpc/kotlin:context",
-    ])
 
     _kt_grpc_library_helper(
         name = kt_grpc_name,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,30 +1,39 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# For use with maven_install's artifacts.
+# maven_install(
+#     ...
+#     artifacts = [
+#         # Your own deps
+#     ] + IO_GRPC_GRPC_KOTLIN_ARTIFACTS + IO_GRPC_GRPC_JAVA_ARTIFACTS,
+# )
 IO_GRPC_GRPC_KOTLIN_ARTIFACTS = [
     "com.google.guava:guava:29.0-jre",
     "com.squareup:kotlinpoet:1.5.0",
     "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",
 ]
 
+# For use with maven_install's override_targets.
+# maven_install(
+#     ...
+#     override_targets = dict(
+#         IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS.items() +
+#         IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS.items(),
+#         "your.target:artifact": "@//third_party/artifact",
+#     )
 IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS = dict()
 
+# Call this after compat_repositories() to load all dependencies.
 def grpc_kt_repositories():
-    if not native.existing_rule("bazel_build_rules_android"):
-        _bazel_build_rules_android()
+    """Imports dependencies for kt_jvm_grpc.bzl"""
     if not native.existing_rule("io_bazel_rules_kotlin"):
-        _io_bazel_rules_kotlin()
+        io_bazel_rules_kotlin()
     if not native.existing_rule("com_google_protobuf"):
-        _com_google_protobuf()
+        com_google_protobuf()
+    if not native.existing_rule("io_grpc_grpc_java"):
+        io_grpc_grpc_java()
 
-def _bazel_build_rules_android():
-    http_archive(
-        name = "build_bazel_rules_android",
-        urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-        sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-        strip_prefix = "rules_android-0.1.1",
-    )
-
-def _io_bazel_rules_kotlin():
+def io_bazel_rules_kotlin():
     rules_kotlin_version = "b40d920c5a5e044c541513f0d5e9260d0a4579c0"
     http_archive(
         name = "io_bazel_rules_kotlin",
@@ -34,10 +43,18 @@ def _io_bazel_rules_kotlin():
         strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
     )
 
-def _com_google_protobuf():
+def com_google_protobuf():
     http_archive(
         name = "com_google_protobuf",
         sha256 = "60d2012e3922e429294d3a4ac31f336016514a91e5a63fd33f35743ccfe1bd7d",
         strip_prefix = "protobuf-3.11.0",
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.0.zip"],
+    )
+
+def io_grpc_grpc_java():
+    http_archive(
+        name = "io_grpc_grpc_java",
+        sha256 = "e274597cc4de351b4f79e4c290de8175c51a403dc39f83f1dfc50a1d1c9e9a4f",
+        strip_prefix = "grpc-java-1.28.0",
+        url = "https://github.com/grpc/grpc-java/archive/v1.28.0.zip",
     )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,43 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+IO_GRPC_GRPC_KOTLIN_ARTIFACTS = [
+    "com.google.guava:guava:29.0-jre",
+    "com.squareup:kotlinpoet:1.5.0",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",
+]
+
+IO_GRPC_GRPC_KOTLIN_OVERRIDE_TARGETS = dict()
+
+def grpc_kt_repositories():
+    if not native.existing_rule("bazel_build_rules_android"):
+        _bazel_build_rules_android()
+    if not native.existing_rule("io_bazel_rules_kotlin"):
+        _io_bazel_rules_kotlin()
+    if not native.existing_rule("com_google_protobuf"):
+        _com_google_protobuf()
+
+def _bazel_build_rules_android():
+    http_archive(
+        name = "build_bazel_rules_android",
+        urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
+        sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+        strip_prefix = "rules_android-0.1.1",
+    )
+
+def _io_bazel_rules_kotlin():
+    rules_kotlin_version = "b40d920c5a5e044c541513f0d5e9260d0a4579c0"
+    http_archive(
+        name = "io_bazel_rules_kotlin",
+        urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
+        sha256 = "3dadd0ad7272be6b1ed1274f62cadd4a1293c89990bcd7b4af32637a70ada63e",
+        type = "zip",
+        strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
+    )
+
+def _com_google_protobuf():
+    http_archive(
+        name = "com_google_protobuf",
+        sha256 = "60d2012e3922e429294d3a4ac31f336016514a91e5a63fd33f35743ccfe1bd7d",
+        strip_prefix = "protobuf-3.11.0",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.0.zip"],
+    )


### PR DESCRIPTION
- Add `repositories.bzl` to make it easy to build transitive deps in Bazel.
- Move the `java_grpc_library` **out** of `kt_jvm_grpc_library` and into a dep. This means that projects that need both a java and a kt version don't need two separate java_grpc_libraries (one internal one and one useful one).